### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/to_regexp.gemspec
+++ b/to_regexp.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Provides String#to_regexp}
   s.description = %q{Provides String#to_regexp, for example if you want to make regexps out of a CSV you just imported.}
 
-  s.rubyforge_project = "to_regexp"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436