### PR TITLE
Add complete dev dependencies and testing on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+language: ruby
+sudo: false
+
+script:
+  - bundle exec rake $TASK
+
+os:
+  - linux
+  - osx
+rvm:
+  - "ruby-1.9.3-p551"
+  - "2.0.0"
+  - "2.1.0"
+  - "2.2.0"
+  - "2.3.0"
+  - "2.4.0"
+  - "2.5.0"
+  - "2.6.0"
+  - "2.7.0"
+  - "ruby-head"
+  - "jruby-9.1.0.0"
+  - "jruby-head"
+  - "truffleruby-head"
+  - "mruby-head"
+
+jobs:
+  exclude:
+    # These combinations fail to even install ruby or bundler on Travis:
+    # The command "rvm use 2.1.0 --install --binary --fuzzy" failed and exited with 2 during .
+    - os: osx
+      rvm: "ruby-1.9.3-p551"
+    - os: osx
+      rvm: "2.0.0"
+    - os: osx
+      rvm: "2.1.0"
+    - os: osx
+      rvm: "2.2.0"
+    - os: osx
+      rvm: "2.3.0"
+    # dyld: lazy symbol binding failed: Symbol not found: ____chkstk_darwin
+    - os: osx
+      rvm: "truffleruby-head"
+
+  # TODO these have real test failures:
+  allow_failures:
+    - rvm: "ruby-head"
+    - rvm: "truffleruby-head"

--- a/to_regexp.gemspec
+++ b/to_regexp.gemspec
@@ -19,5 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency 'ensure-encoding'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'test-unit'
   s.add_development_dependency 'yard'
 end


### PR DESCRIPTION
Hi.  I noticed `bundle exec rake` didn't work out of the box, added missing dependencies.

Added Travis testing.  See https://www.travis-ci.org/github/cben/to_regexp/builds/698302654 for an example build on my fork.
- You'll need to enable the repo at https://www.travis-ci.org/github/seamusabshere/to_regexp.

A test matrix of over 20 jobs is a bit overkill, and Mac doesn't seem to add any info that Linux didn't show, but this project is not very active so why not :shrug: 
I see this codebase still cares about Ruby 1.8, though I suspect you no long do, what with 2.4 being EOL :wink:   Anyway, 1.9 is oldest readily available on Travis.

A few tests actually fail on ruby-head & truffleruby-head.  I don't know enough to attempt fixing those. Marked "allow_failures" for now so this can be useful for checking PRs.